### PR TITLE
Fix typos in internals.rs

### DIFF
--- a/src/httpcommon/headers/internals.rs
+++ b/src/httpcommon/headers/internals.rs
@@ -23,7 +23,7 @@ use super::{Header, UncheckedAnyMutRefExt, fmt_header};
 /// - `raw_valid == true` requires `raw` to be some with `.len() > 0`.
 pub struct Item {
     /// Whether the raw header form is valid. If a mutable reference is taken to `typed`, this will
-    /// be set to `true`, meaning that for the purposes of reading, `raw` must be considered to be
+    /// be set to `false`, meaning that for the purposes of reading, `raw` must be considered to be
     /// invalid and must be produced once again. This exists as a slight efficiency improvement over
     /// just resetting `raw` to `None` in that, if the raw form is read again, the raw vectors can
     /// be reused; this is almost certain to be faster than dropping the vectors and creating new
@@ -91,7 +91,7 @@ impl Item {
     /// Get a mutable reference to the raw representation of the header values.
     ///
     /// Because you may modify the raw representation through this mutable reference, calling this
-    /// this invalidates the typed representation; next time you want to access the value in typed
+    /// invalidates the typed representation; next time you want to access the value in typed
     /// fashion, it will be parsed from the raw form.
     ///
     /// Only use this if you need to mutate the raw form; if you don't, use `raw_ref`.
@@ -171,32 +171,32 @@ impl Item {
         }
     }
 
-    /// Get a mutable reference to the raw representation of the header values.
+    /// Get a mutable reference to the typed representation of the header values.
     ///
-    /// Because you may modify the raw representation through this mutable reference, calling this
-    /// this invalidates the typed representation; next time you want to access the value in typed
-    /// fashion, it will be parsed from the raw form.
+    /// Because you may modify the typed representation through this mutable reference, calling
+    /// this invalidates the raw representation; next time you want to access the value in raw
+    /// fashion, it will be produced from the typed form.
     ///
-    /// Only use this if you need to mutate the raw form; if you don't, use `raw_ref`.
+    /// Only use this if you need to mutate the typed form; if you don't, use `typed_ref`.
     pub fn typed_mut_ref<'a, H: Header + 'static>(&'a mut self) -> Option<&'a mut H> {
         self.typed_mut_ref_internal(true)
     }
 
-    /// Get a reference to the raw representation of the header values.
+    /// Get a reference to the typed representation of the header values.
     ///
-    /// If a valid raw representation exists, it will be used, making this a very cheap operation;
-    /// if it does not, then the typed representation will be converted to raw form and you will
-    /// then get a reference to that. In summary, it doesn't much matter; you'll get your raw
+    /// If a valid typed representation exists, it will be used, making this a very cheap operation;
+    /// if it does not, then the raw representation will be converted to typed form and you will
+    /// then get a reference to that. In summary, it doesn't much matter; you'll get your typed
     /// reference.
     ///
-    /// See also `raw_mut_ref`, if you wish to mutate the raw representation.
+    /// See also `typed_mut_ref`, if you wish to mutate the typed representation.
     pub fn typed_ref<'a, H: Header + 'static>(&'a mut self) -> Option<&'a H> {
         self.typed_mut_ref_internal(false).map(|h| &*h)
     }
 
-    /// Set the raw form of the header.
+    /// Set the typed form of the header.
     ///
-    /// This invalidates the typed representation.
+    /// This invalidates the raw representation.
     pub fn set_typed<'a, H: Header + 'static>(&mut self, value: H) {
         self.raw_valid = false;
         self.typed = Some(box value as Box<Header + 'static>);


### PR DESCRIPTION
The doc comments for `typed_mut_ref()` and `typed_ref()` were the same as the doc comments for `raw_mut_ref()` and `raw_ref()`. I also found + fixed a couple other documentation typos in the same file.
